### PR TITLE
Fixing markers wrong locations

### DIFF
--- a/L.KML.js
+++ b/L.KML.js
@@ -407,12 +407,12 @@ L.KMLIcon = L.Icon.extend({
 	},
 	_setIconStyles: function (img, name) {
 		L.Icon.prototype._setIconStyles.apply(this, [img, name]);
-		if( img.complete ) {
-			this.applyCustomStyles( img )
-		} else {
-			img.onload = this.applyCustomStyles.bind(this,img)
-		}
-
+	},
+	_createImg: function (src, el) {
+		el = el || document.createElement('img');
+		el.onload = this.applyCustomStyles.bind(this,el)
+		el.src = src;
+		return el;
 	},
 	applyCustomStyles: function(img) {
 		var options = this.options;


### PR DESCRIPTION
This pull request fixes markers wrong location:
You can reproduce the issue by uploading example2 from this repo to the https://www.windy.com/ website, uploading it again and switching between the two.

![image](https://user-images.githubusercontent.com/8260668/80827060-f4459e00-8beb-11ea-8e88-b8791acec7d6.png)

The issue happens because when the image of the icon is already cached, it's height is still 0 when trying to apply the custom styles (applyCustomStyles function).

The implementation in this PR allows new and older browser support by defining the onload event before assigning the source for the image (https://stackoverflow.com/questions/12354865/image-onload-event-and-browser-cache)
by overriding the _createImg method.
In this way, the onload event always fire and the height of the image is always available. 