### PR TITLE
FIX: Crashing on <MultiGeometry></MultiGeometry> in a <Placemark>

### DIFF
--- a/L.KML.js
+++ b/L.KML.js
@@ -225,6 +225,8 @@ L.Util.extend(L.KML, {
 			el = place.getElementsByTagName(multi[h]);
 			for (i = 0; i < el.length; i++) {
 				var layer = this.parsePlacemark(el[i], xml, style, opts);
+				if (layer === undefined)
+					continue;
 				this.addPlacePopup(place, layer);
 				return layer;
 			}

--- a/Test - comit with access token.txt
+++ b/Test - comit with access token.txt
@@ -1,1 +1,0 @@
-Hello World!

--- a/Test - comit with access token.txt
+++ b/Test - comit with access token.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
Your library is great. I'm rewriting our company's map web app to use free open solutions because we are tired of paying Google thousands of Euro every month for years. However I found a KML file where L.KML.js crashed. The file is created form a geodetic tool, not by hand. Since I can't change that software and want to use the produced KML files without fixing them manually (people update them multiple times a year and we have hundreds of maps), I added 2 lines in your library to be able to handle such files:

Map page (to see what the web app does):
https://www.dlubal.com/en/load-zones-for-snow-wind-earthquake/snow-din-en-1991-1-3.html

Map page with OpenStreepMap and your library - currently the free open code is not integrated in the functionality, just displaying it loads the data and shows it (to see your library in use):
https://www.dlubal.com/en/load-zones-for-snow-wind-earthquake/snow-din-en-1991-1-3.html?osm=1

Used KML file:
https://loadzones.dlubal.com/file.aspx?kml=snow-din-en-1991-1-3-l1-v545.kml

Probably problematic part:
```
  <Placemark>
	<name>N/A</name>
	<Style><LineStyle><color>ff808080</color><width>1</width></LineStyle><PolyStyle><fill>1</fill><color>80C0C0C0</color></PolyStyle></Style>
	<ExtendedData><SchemaData schemaUrl="#DE_snow_update_2020819">
		<SimpleData name="tessellate">-1</SimpleData>
		<SimpleData name="extrude">0</SimpleData>
		<SimpleData name="visibility">-1</SimpleData>
	</SchemaData></ExtendedData>
      <MultiGeometry></MultiGeometry>    <-- HERE
  </Placemark>

```
To find place in your code, I just went by the JS error in the web console. Up one function from the one it crashed on "layer" being null.

I visually checked the displayed KML layer on the web app and it's identical to the one loaded in Google Maps version.