### PR TITLE
Small fix to prevent double adding layers.

### DIFF
--- a/L.KML.js
+++ b/L.KML.js
@@ -40,18 +40,18 @@ L.Util.extend(L.KML, {
 		for (var i = 0; i < el.length; i++) {
 			if (!this._check_folder(el[i])) { continue; }
 			l = this.parseFolder(el[i], style);
-			if (l) { layers.push(l); }
+            if (l) { layers.push(l); l.remove(); }
 		}
 		el = xml.getElementsByTagName('Placemark');
 		for (var j = 0; j < el.length; j++) {
 			if (!this._check_folder(el[j])) { continue; }
 			l = this.parsePlacemark(el[j], xml, style);
-			if (l) { layers.push(l); }
+			if (l) { layers.push(l); l.remove();}
 		}
 		el = xml.getElementsByTagName('GroundOverlay');
 		for (var k = 0; k < el.length; k++) {
 			l = this.parseGroundOverlay(el[k]);
-			if (l) { layers.push(l); }
+			if (l) { layers.push(l); l.remove();}
 		}
 		return layers;
 	},


### PR DESCRIPTION
Hi. I faced the problem of adding layers twice when exporting data from Google Earth to a KML file. Google Earth wraps "GroundOverlay" in "Folder". And so after parsing my image layers were added twice. Perhaps this fix will help someone.